### PR TITLE
fix: due to recent netgen changes adjust the expected value from 4 to 2

### DIFF
--- a/by_id/netgen.lvs/003-fail-no-flatten/handler.py
+++ b/by_id/netgen.lvs/003-fail-no-flatten/handler.py
@@ -1,7 +1,7 @@
 def handle(step):
     metric_name = "design__lvs_error__count"
     metric_value = step.state_out.metrics[metric_name]
-    expected_value = 4
+    expected_value = 2
 
     assert (
         metric_value == expected_value


### PR DESCRIPTION
After an update to nix-eda, a test case for netgen failed:

```
SUBPROCESS __librelane__:step.py:185 Class: sky130_fd_sc_hd__tapvpwrvgnd_1 instances:   1
SUBPROCESS __librelane__:step.py:185 Class: sky130_fd_sc_hd__fill_1 instances:   1
SUBPROCESS __librelane__:step.py:185 Class: sky130_fd_sc_hd__fill_2 instances:   1
SUBPROCESS __librelane__:step.py:185 Circuit contains 386 nets, and 1 disconnected pin.
SUBPROCESS __librelane__:step.py:185 
SUBPROCESS __librelane__:step.py:185 Circuit 1 contains 357 devices, Circuit 2 contains 358 devices. *** MISMATCH ***
SUBPROCESS __librelane__:step.py:185 Circuit 1 contains 386 nets,    Circuit 2 contains 386 nets.
```

There have been changes in netgen lately to improve handling of devices with no ports (https://github.com/RTimothyEdwards/netgen/commit/b5432d139bb58a87c9fb642ffcd1ef550a269766) and more. This could have changed the number of errors reported.

Since the test case is still failing I would say it is okay to adjust the expected value.
Instead of an `design__lvs_error__count` of 4 we now expect one of 2.

I'll merge this in order to continue with my PR, let me know if I should revert it.