### PR TITLE
fix: change image name to design name

### DIFF
--- a/by_id/klayout.render/001-success/handler.py
+++ b/by_id/klayout.render/001-success/handler.py
@@ -3,7 +3,7 @@ from PIL import Image
 
 
 def handle(step):
-    image = os.path.join(step.step_dir, "out.png")
+    image = os.path.join(step.step_dir, "spm.png")
 
     with Image.open(image) as im:
         im.verify()


### PR DESCRIPTION
I forgot to merge this after updating KLayout.Render...

LibreLane dev currently points to this branch. I'm going to merge this and we can update dev afterwards.